### PR TITLE
Add coeff gwbuckparm parameter as perturbable parameter

### DIFF
--- a/djs/cli/djs.py
+++ b/djs/cli/djs.py
@@ -146,7 +146,7 @@ def perturbation_engine(setup_yaml):
     \b
     Supported WRF-Hydro/NWM parameters:
         Route_link.nc: BtmWdth, ChSlp, n, nCC, TopWdth, TopWdthCC, BtmWdth
-        GWBUCKPARM.nc : Expon, Zinit, Zmax
+        GWBUCKPARM.nc : Coeff, Expon, Zinit, Zmax
         LAKEPARM.nc : OrificeA, OrificeC, OrificeE, WeirC, WeirE, WeirL
         soil_properties.nc: mfsno
         Fulldom_hires.nc : LKSATFAC, OVROUGHRTFAC, RETDEPRTFAC

--- a/djs/perturbation_engine/parameter_editor.py
+++ b/djs/perturbation_engine/parameter_editor.py
@@ -21,7 +21,7 @@ def _check_parameter_validity(parameter_file: Union[str, xr.core.dataset.Dataset
     # with valid paramters to vary as their values
     valid_files_to_edit = {
     'Route_link.nc': {'ChSlp', 'n', 'nCC', 'TopWdth', 'TopWdthCC', 'BtmWdth'},
-    'GWBUCKPARM.nc' : {'Expon', 'Zinit', 'Zmax'},
+    'GWBUCKPARM.nc' : {'Coeff', 'Expon', 'Zinit', 'Zmax'},
     'LAKEPARM.nc' : {'OrificeA', 'OrificeC', 'OrificeE', 'WeirC', 'WeirE', 'WeirL'},
     'soil_properties.nc': {'mfsno'},
     'Fulldom_hires.nc' : {'LKSATFAC', 'OVROUGHRTFAC', 'RETDEPRTFAC'}


### PR DESCRIPTION
## Additions:
- Make possible to ability to perturb the `Coeff` parameter in the `GWBUCKPARM.nc` file.
- Update CLI docs to reflect this addition.
